### PR TITLE
IS-263

### DIFF
--- a/gelcoverage/stats/coverage_stats.py
+++ b/gelcoverage/stats/coverage_stats.py
@@ -290,7 +290,7 @@ def compute_whole_genome_statistics(bigwig_reader, bed_reader=None, chunk_size=1
                 logging.debug("Analysing chunk %s:%s-%s" % (chromosome,
                                                             current_start,
                                                             current_end))
-                coverages = bigwig_reader.read_bigwig_coverages(chromosome, current_start, current_end, strict=False)
+                coverages = bigwig_reader.read_bigwig_coverages(chromosome, current_start, current_end, strict=True)
                 length = current_end - current_start
                 chunk_mean = np.mean(coverages)
                 if chunk_mean == 0:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import io
 
 # read the contents of your README file
 
-VERSION = '1.4.3'
+VERSION = '1.4.4'
 
 setup(
     name='gel-coverage',


### PR DESCRIPTION
As we pull the analysis regions out here -

`[analysis_regions = bed_reader.get_regions_dictionary()]`

And this contains only the non-N regions, we can query pybigwig with the strict reader which is compatible with bigwigs produced by dragen prior to 3.2.22.  The strict reader is not compatible with bedcov based bigwigs.  

I've tested this by patching an older version of bertha-compute with a 100k bigwig generated by coverage_bigwig and with a dragen based bigwig